### PR TITLE
Refactor: fastapi app

### DIFF
--- a/FastAPI/app.py
+++ b/FastAPI/app.py
@@ -17,31 +17,40 @@ def get_current_semester():
     now = datetime.now()
     year = now.year
     month = now.month
+    return f"{year}_1" if month <= 8 else f"{year}_2"
 
-    if month <= 8:
-        return f"{year}_1"
-    else:
-        return f"{year}_2"
+@app.on_event("startup")
+def load_model_on_startup():
+    current_semester = get_current_semester()
+    model = load_model(
+        model_name=f"{current_semester}_classification_model",
+        platform='aws',
+        authentication={
+            'bucket': AWS_BUCKET_NAME,
+            'path': "models/"
+        }
+    )
+    app.state.model = model
 
 @app.get("/")
 def read_root():
     return {"Hello": "World"}
 
 @app.post("/prediction", response_model=PredictOutput)
-async def inference(item_list: DataInput):
-    item_dict = {'firstMajor': item_list.firstMajor, 
-                 'applyGrade': item_list.applyGrade, 
-                 'applyMajor': item_list.applyMajor, 
-                 'applySemester': item_list.applySemester, 
-                 'applyGPA': item_list.applyGPA}
+def inference(item_list: DataInput):
+    item_dict = {
+        'firstMajor': item_list.firstMajor,
+        'applyGrade': item_list.applyGrade,
+        'applyMajor': item_list.applyMajor,
+        'applySemester': item_list.applySemester,
+        'applyGPA': item_list.applyGPA
+    }
     df = pd.DataFrame([item_dict])
 
-    current_semester = get_current_semester()
-    classification_model = load_model(model_name=f"{current_semester}_classification_model",
-                                      platform='aws', 
-                                      authentication={'bucket': AWS_BUCKET_NAME, 
-                                                      'path': "models/"})
-    prediction = predict_model(classification_model, data=df)
+    model = app.state.model
+    prediction = predict_model(model, data=df)
 
-    return {"prediction_label": prediction.iloc[0]['prediction_label'],
-            "prediction_score": prediction.iloc[0]['prediction_score']}
+    return {
+        "prediction_label": prediction.iloc[0]['prediction_label'],
+        "prediction_score": prediction.iloc[0]['prediction_score']
+    }


### PR DESCRIPTION
- load model on first app startup instead of every inference request
- cpu bound task to threadpool, so it doesn't block event loop